### PR TITLE
fix(installer): resolve latest bundle by semantic version

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -443,18 +443,29 @@ function Get-PluginBundleFromAssets {
 
     $assetsUri = "https://api.github.com/repos/$GITHUB_SOURCE_REPO/contents/assets?ref=$GITHUB_SOURCE_BRANCH"
     $assets = Invoke-RestMethod -Uri $assetsUri -Headers $headers -ErrorAction Stop
-    $bundle = $assets | Where-Object { $_.name -like "opencode-multi-auth-*.tar.gz" } | Sort-Object name -Descending | Select-Object -First 1
+    $bundle = $assets |
+        Where-Object { $_.name -match '^opencode-multi-auth-v(?<version>\d+\.\d+\.\d+)\.tar\.gz$' } |
+        ForEach-Object {
+            [PSCustomObject]@{
+                Asset   = $_
+                Version = [version]$Matches.version
+            }
+        } |
+        Sort-Object Version -Descending |
+        Select-Object -First 1
     if (-not $bundle) {
         throw "No plugin bundle found in assets/ for $GITHUB_SOURCE_REPO@$GITHUB_SOURCE_BRANCH"
     }
+
+    $bundleName = $bundle.Asset.name
 
     $downloadHeaders = @{
         Authorization = "token $Token"
         Accept        = "application/vnd.github.raw"
     }
-    $downloadUri = "https://api.github.com/repos/$GITHUB_SOURCE_REPO/contents/assets/$($bundle.name)?ref=$GITHUB_SOURCE_BRANCH"
+    $downloadUri = "https://api.github.com/repos/$GITHUB_SOURCE_REPO/contents/assets/$bundleName?ref=$GITHUB_SOURCE_BRANCH"
     Invoke-WebRequest -Uri $downloadUri -Headers $downloadHeaders -OutFile $OutPath -UseBasicParsing -ErrorAction Stop
-    return $bundle.name
+    return $bundleName
 }
 
 function Get-Asset {

--- a/install.sh
+++ b/install.sh
@@ -440,7 +440,7 @@ download_plugin_bundle() {
     "${assets_api}")"
 
   local bundle_name
-  bundle_name="$(printf '%s' "${assets_json}" | grep -o '"name": *"opencode-multi-auth-[^"]*\.tar\.gz"' | head -1 | cut -d '"' -f4)"
+  bundle_name="$(printf '%s' "${assets_json}" | grep -o '"name": *"opencode-multi-auth-v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz"' | cut -d '"' -f4 | sort -V | tail -1)"
   [[ -n "${bundle_name}" ]] || error "No plugin bundle found in assets/ for ${GITHUB_SOURCE_REPO}@${GITHUB_SOURCE_BRANCH}"
 
   local file_api="https://api.github.com/repos/${GITHUB_SOURCE_REPO}/contents/assets/${bundle_name}?ref=${GITHUB_SOURCE_BRANCH}"


### PR DESCRIPTION
## Summary
- Fix Windows bundle resolver to select `opencode-multi-auth-vX.Y.Z.tar.gz` by semantic version, not lexicographic filename order.
- Fix shell installer bundle resolver to use semantic ordering (`sort -V`) instead of first-match API ordering.
- Prevent stale bundle resolution where `v2.0.9` could be picked while `v2.0.12` exists.

## Verification
- Confirmed live beta assets contain `v2.0.10`, `v2.0.11`, `v2.0.12`.
- Verified semantic ordering now resolves `opencode-multi-auth-v2.0.12.tar.gz`.