### PR TITLE
fix(installer): correct PowerShell bundle download URI interpolation

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -463,7 +463,7 @@ function Get-PluginBundleFromAssets {
         Authorization = "token $Token"
         Accept        = "application/vnd.github.raw"
     }
-    $downloadUri = "https://api.github.com/repos/$GITHUB_SOURCE_REPO/contents/assets/$bundleName?ref=$GITHUB_SOURCE_BRANCH"
+    $downloadUri = "https://api.github.com/repos/$GITHUB_SOURCE_REPO/contents/assets/${bundleName}?ref=$GITHUB_SOURCE_BRANCH"
     Invoke-WebRequest -Uri $downloadUri -Headers $downloadHeaders -OutFile $OutPath -UseBasicParsing -ErrorAction Stop
     return $bundleName
 }


### PR DESCRIPTION
## Summary
- Fix PowerShell string interpolation in installer bundle download URI.
- Prevent `$bundleName?ref` from being parsed as a variable name, which broke download after semver resolver update.
- Keep semver bundle selection intact so latest beta tarball is selected.

## Verification
- Executed installer locally from patched script and confirmed:
  - `Resolved bundle: opencode-multi-auth-v2.0.12.tar.gz`
  - bundle download/extract succeeds
  - setup banner reports latest version path correctly