### PR TITLE
docs(installer): define strict public scope and release gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,27 @@ irm https://raw.githubusercontent.com/andyvandaric/opencode-suites-installer/mai
 
 - If your GitHub account has beta access, installer pulls bundle from buyer beta channel.
 - If access is missing, installer redirects to WhatsApp purchase CTA.
+
+## Public Repo Scope (Strict)
+
+This public installer repository is intentionally minimal.
+
+### Allowed in `main`
+
+- `README.md`
+- `install.ps1`
+- `install.sh`
+
+### Not Allowed in `main`
+
+- Any source directories (for example `plugins/`, `apps/`, `scripts/`, `plans/`, `.github/`).
+- Any release/build/runtime artifacts (`node_modules/`, coverage files, temp files).
+- Any config or internal orchestration files from private development repos.
+
+### Release Gate (must pass before merge)
+
+1. `git ls-files` returns only the 3 allowed files above.
+2. PR diff only touches `README.md`, `install.ps1`, or `install.sh`.
+3. Installer smoke run resolves the latest semantic bundle from `assets/opencode-multi-auth-vX.Y.Z.tar.gz`.
+
+If a change needs anything outside these 3 files, it belongs in the private source workflow, not in this public installer repo.


### PR DESCRIPTION
## Summary
- Define strict public-repo scope in `README.md` with explicit allowlist and denylist.
- Document that public installer `main` must only contain `README.md`, `install.ps1`, and `install.sh`.
- Add release gate checklist to prevent accidental cross-repo file leakage.

## Scope Policy
- Allowed: `README.md`, `install.ps1`, `install.sh`
- Not allowed: source trees, CI/workflow files, build artifacts, private repo internals.