### PR TITLE
ci(installer): add scope guard and cross-platform smoke checks

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,0 +1,71 @@
+name: Installer Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert shell resolver uses semantic ordering
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          grep -qE 'sort -V \| tail -1' install.sh
+
+          sample_names=$'opencode-multi-auth-v2.0.9.tar.gz\nopencode-multi-auth-v2.0.10.tar.gz\nopencode-multi-auth-v2.0.11.tar.gz\nopencode-multi-auth-v2.0.12.tar.gz'
+          selected="$(printf '%s\n' "$sample_names" | grep -E '^opencode-multi-auth-v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$' | sort -V | tail -1)"
+
+          if [[ "$selected" != "opencode-multi-auth-v2.0.12.tar.gz" ]]; then
+            echo "Semantic bundle selection failed on shell path. Selected: $selected"
+            exit 1
+          fi
+
+  smoke-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert PowerShell resolver uses semantic ordering
+        shell: pwsh
+        run: |
+          $script = Get-Content -Path .\install.ps1 -Raw
+
+          if ($script -notmatch 'Sort-Object\s+Version\s+-Descending') {
+            throw 'install.ps1 does not sort bundle candidates by semantic Version descending.'
+          }
+
+          if ($script -notmatch '\$\{bundleName\}\?ref=') {
+            throw 'install.ps1 does not use safe bundleName URI interpolation (${bundleName}?ref=...).'
+          }
+
+          $sample = @(
+            [PSCustomObject]@{ name = 'opencode-multi-auth-v2.0.9.tar.gz' },
+            [PSCustomObject]@{ name = 'opencode-multi-auth-v2.0.10.tar.gz' },
+            [PSCustomObject]@{ name = 'opencode-multi-auth-v2.0.11.tar.gz' },
+            [PSCustomObject]@{ name = 'opencode-multi-auth-v2.0.12.tar.gz' }
+          )
+
+          $selected = $sample |
+            Where-Object { $_.name -match '^opencode-multi-auth-v(?<version>\d+\.\d+\.\d+)\.tar\.gz$' } |
+            ForEach-Object {
+              [PSCustomObject]@{
+                Name = $_.name
+                Version = [version]$Matches.version
+              }
+            } |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
+
+          if ($selected.Name -ne 'opencode-multi-auth-v2.0.12.tar.gz') {
+            throw "Semantic bundle selection failed on PowerShell path. Selected: $($selected.Name)"
+          }

--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -1,0 +1,72 @@
+name: Scope Guard
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  enforce-public-scope:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce tracked-file allowlist
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          allowed_regex='^(README\.md|install\.ps1|install\.sh|\.github/workflows/scope-guard\.yml|\.github/workflows/installer-smoke\.yml)$'
+
+          mapfile -t tracked < <(git ls-files)
+          disallowed=()
+          for file in "${tracked[@]}"; do
+            if [[ ! "$file" =~ $allowed_regex ]]; then
+              disallowed+=("$file")
+            fi
+          done
+
+          if (( ${#disallowed[@]} > 0 )); then
+            echo "Disallowed tracked files found in public installer repository:"
+            printf ' - %s\n' "${disallowed[@]}"
+            exit 1
+          fi
+
+      - name: Enforce changed-file allowlist
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          allowed_regex='^(README\.md|install\.ps1|install\.sh|\.github/workflows/scope-guard\.yml|\.github/workflows/installer-smoke\.yml)$'
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.before }}"
+          fi
+          head_sha="${{ github.sha }}"
+
+          if [[ -z "$base_sha" || "$base_sha" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No comparable base SHA (initial push). Skipping changed-file diff gate."
+            exit 0
+          fi
+
+          mapfile -t changed < <(git diff --name-only "$base_sha" "$head_sha")
+          disallowed=()
+          for file in "${changed[@]}"; do
+            [[ -z "$file" ]] && continue
+            if [[ ! "$file" =~ $allowed_regex ]]; then
+              disallowed+=("$file")
+            fi
+          done
+
+          if (( ${#disallowed[@]} > 0 )); then
+            echo "Disallowed changed files detected for installer release scope:"
+            printf ' - %s\n' "${disallowed[@]}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add `scope-guard` workflow to enforce strict public installer repo allowlist.
- Add `installer-smoke` workflow on Linux + Windows to validate semver bundle selection behavior.
- Guard against regressions that could reintroduce stale bundle resolution or cross-repo file leakage.

## Checks Added
- Tracked-file allowlist gate
- Changed-file allowlist gate
- Shell semver resolver smoke check
- PowerShell semver resolver smoke check